### PR TITLE
Fix for Results URL

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -40,23 +40,21 @@ First, create and configure the Google Custom Search Engine at https://www.googl
 
 - Choose the search engine you want to use under "Edit Search Engine"
 - Under Setup > Basics > Sites to search, list the domain of the sites you want to search
-- Under Setup > Admin, add any colleague with whom you want to share administration of the search engine 
+- Under Setup > Admin, add any colleague with whom you want to share administration of the search engine
 - Under Look and Feel > Layout, choose "Two page", then:
 -- Click "Save and Get Code"
--- On the next page, click "Search Results Details" and enter https://<yourwebsite url>.stanford.edu/search
-   (your website's URL + /search) as the complete URL of your site where you want the search results to appear.
 -- Specify the query parameter as: "q_as"
 -- Click Save
 - Under Business > Settings, select "do not show ads on results pages" if this is a stanford.edu website.
 - Under Look and Feel > Themes, choose Default
 - Under Look and Feel > Customize, choose the colors that best match your website
-- Under Setup > Basics, in the details, click the "Search Engine ID" button. You'll need this ID to configure the module. 
+- Under Setup > Basics, in the details, click the "Search Engine ID" button. You'll need this ID to configure the module.
   Your search engine's ID will be displayed in a pop-up. Copy and paste it into the configuration page for the module.
 
 Then, configure the module on your Drupal site  at Administer > Site Configuration > Search and Metadata > Stanford Search.
 
 - Enter the ID retrieved in the last step above
-
+- Enter your desired search results path with preceding slash, (e.g. /search)
 
 -- KNOWN ISSUES --
 

--- a/stanford_search.admin.inc
+++ b/stanford_search.admin.inc
@@ -17,7 +17,15 @@ function stanford_search_admin_settings($form, &$form_state) {
     '#size'  => 80,
     '#maxlength' => 255,
     '#default_value' => variable_get('stanford_search_engine_id',''),
-    '#description' => t('The custom search engine&rsquo;s unique ID'), 
+    '#description' => t('The custom search engine&rsquo;s unique ID'),
   );
+  $form['stanford_search_engine_results_page'] = array(
+  '#type'  => 'textfield',
+  '#title' => 'Google Custom Search Results Page',
+  '#size'  => 80,
+  '#maxlength' => 255,
+  '#default_value' => variable_get('stanford_search_engine_results_page',''),
+  '#description' => t('The search page path, with preceding slash (e.g. /search) where results should appear'),
+);
   return system_settings_form($form);
 }

--- a/stanford_search.install
+++ b/stanford_search.install
@@ -17,7 +17,7 @@ function stanford_search_requirements($phase) {
         'title' => $t('Stanford Search - Google Custom Search Engine'),
         'value' => $t("The engine&rsquo;s unique ID is set to @id", array('@id' => $id)),
         'severity' => REQUIREMENT_OK,
-      ); 
+      );
     }
   }
 
@@ -26,4 +26,5 @@ function stanford_search_requirements($phase) {
 
 function stanford_search_uninstall() {
   variable_del('stanford_search_engine_id');
+  variable_del('stanford_search_engine_results_page');
 }

--- a/stanford_search.module
+++ b/stanford_search.module
@@ -50,10 +50,11 @@ function stanford_search_block_view($delta = '') {
   switch ($delta) {
     case 'stanford_search_search':
       global $base_url;
-	  $block['content'] = array(
-	    '#markup' => '<gcse:searchbox-only linktarget="' . $base_url . '" queryparametername="q_as"></gcse:searchbox-only>',
+      $results_page_path = variable_get('stanford_search_engine_results_page','');
+      $block['content'] = array(
+        '#markup' => '<gcse:searchbox-only queryparametername="q_as" resultsUrl="' . $base_url . $results_page_path . '"></gcse:searchbox-only>',
       );
-	  break;
+    break;
   }
   return $block;
 }


### PR DESCRIPTION
Howdy, my name is Dustin, with [Four Kitchens](https://fourkitchens.com/). We provide support for the [Dean of Research](https://doresearch.stanford.edu). I was recently asked to test Google CSE integration using this module, and I ran into some trouble with the implementation.

It appears that Google has updated their CSE admin interface, and it's no longer possible to input the search results URL as described in your README. I checked their documentation [here](https://support.google.com/customsearch/answer/3037004?hl=en) and [here](https://developers.google.com/custom-search/docs/tutorial/implementingsearchbox#trying_out_different_layouts), and it seemed like a reasonable option would be to modify the module to allow for manual input of the results path in Drupal, and output the necessary `resultsUrl` as a variable in the `hook_block_view`.

I've attached my work as a PR against the current master version, for ease of review, although I am currently using these modifications against the code from PR #1 successfully.

Hope this is helpful, please let me know if I need to modify this in any way.
